### PR TITLE
Remove all references to the crossterm book

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Version master
 
 - Add deprecation note
+- Remove all references to the crossterm book
 
 # Version 0.3.1
 

--- a/src/command.rs
+++ b/src/command.rs
@@ -8,7 +8,6 @@ use crate::{execute, impl_display, queue, write_cout, Result};
 /// crossterm already delivers a number of commands.
 /// There is no need to implement them yourself.
 /// Also, you don't have to execute the commands yourself by calling a function.
-/// For more information see the [command API](https://crossterm-rs.github.io/crossterm/docs/command.html)
 pub trait Command {
     type AnsiType: Display;
 
@@ -53,8 +52,6 @@ where
     /// - When the buffer is to full, then the terminal will flush for you.
     /// - Incase of `stdout` each line, because `stdout` is line buffered.
     ///
-    /// Check the [command API](https://crossterm-rs.github.io/crossterm/docs/command.html) for more information and all available commands.
-    ///
     /// # Parameters
     /// - [Command](./trait.Command.html)
     ///
@@ -82,8 +79,6 @@ where
     ///
     /// In case you have many executions after on and another you can use `queue(command)` to get some better performance.
     /// The `queue` function will not call `flush`.
-    ///
-    /// Check the [command API](https://crossterm-rs.github.io/crossterm/docs/command.html) for more information and all available commands.
     ///
     /// # Remarks
     /// - In the case of UNIX and windows 10, ANSI codes are written to the given 'writer'.

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -34,8 +34,6 @@ macro_rules! write_cout {
 /// - When the buffer is to full, then the terminal will flush for you.
 /// - Incase of `stdout` each line, because `stdout` is line buffered.
 ///
-/// Check [here](https://crossterm-rs.github.io/crossterm/docs/command.html) for more information and all availible commands.
-///
 /// # Parameters
 /// - [std::io::Writer](https://doc.rust-lang.org/std/io/trait.Write.html)
 ///
@@ -113,8 +111,6 @@ macro_rules! queue {
 }
 
 /// Execute one or more command(s)
-///
-/// Check [here](https://crossterm-rs.github.io/crossterm/docs/command.html) for more information and all availible commands.
 ///
 /// # Parameters
 /// - [std::io::Writer](https://doc.rust-lang.org/std/io/trait.Write.html)


### PR DESCRIPTION
To be merged once the new book with warnings will be online.