### PR TITLE
Remove static mut

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 - Add deprecation note
 - Remove all references to the crossterm book
-- `sys::unix::RAW_MODE_ENABLED` replaced with `sys::unix::is_raw_mode_enabled()`
+- `sys::unix::RAW_MODE_ENABLED` replaced with `sys::unix::is_raw_mode_enabled()` (breaking)
 - New `lazy_static` dependency
 
 # Version 0.3.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
-# Version master
+# Version 0.4.0
 
 - Add deprecation note
 - Remove all references to the crossterm book
+- `sys::RAW_MODE_ENABLED` replaced with `sys::is_raw_mode_enabled()`
 
 # Version 0.3.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 - Add deprecation note
 - Remove all references to the crossterm book
-- `sys::RAW_MODE_ENABLED` replaced with `sys::is_raw_mode_enabled()`
+- `sys::unix::RAW_MODE_ENABLED` replaced with `sys::unix::is_raw_mode_enabled()`
 
 # Version 0.3.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
-# Version 0.4.0
+# Version master
 
 - Add deprecation note
 - Remove all references to the crossterm book
 - `sys::unix::RAW_MODE_ENABLED` replaced with `sys::unix::is_raw_mode_enabled()`
+- New `lazy_static` dependency
 
 # Version 0.3.1
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crossterm_utils"
-version = "0.4.0"
+version = "0.3.1"
 authors = ["T. Post"]
 description = "Common logic used by the crossterm crates."
 repository = "https://github.com/crossterm-rs/crossterm-utils"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crossterm_utils"
-version = "0.3.1"
+version = "0.4.0"
 authors = ["T. Post"]
 description = "Common logic used by the crossterm crates."
 repository = "https://github.com/crossterm-rs/crossterm-utils"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,6 @@ crossterm_winapi = { version = "0.2.1" }
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2.51"
+
+[dependencies]
+lazy_static = "1.4"

--- a/src/sys/unix.rs
+++ b/src/sys/unix.rs
@@ -10,7 +10,7 @@ use lazy_static::lazy_static;
 use crate::{ErrorKind, Result};
 
 lazy_static! {
-    // Some(Termios) -> we're in the raw mode and this is the mode previous mode
+    // Some(Termios) -> we're in the raw mode and this is the previous mode
     // None -> we're not in the raw mode
     static ref TERMINAL_MODE_PRIOR_RAW_MODE: Mutex<Option<Termios>> = Mutex::new(None);
 }


### PR DESCRIPTION
* ~~`Cargo.toml` bumped to `0.4.0` (breaking change)~~
* Change log updated
* `sys::unix`
  * `RAW_MODE_ENABLED` replace with `is_raw_mode_enabled()` function
  * `enable_raw_mode()` & `disable_raw_mode()` refactored

---

~~This is breaking change. If you're okay with this PR, please:~~

* ~~merge,~~
* ~~release on GH,~~
* ~~release on crates.io.~~

~~We need this version to update the `crossterm-cursor` crate, which relies on the `RAW_MODE_ENABLED`.~~

Fixes https://github.com/crossterm-rs/crossterm/issues/245